### PR TITLE
audit fixes: remove interchain_tx_in_progress from state

### DIFF
--- a/integration-tests/artifacts/scripts/init-neutrond.sh
+++ b/integration-tests/artifacts/scripts/init-neutrond.sh
@@ -10,7 +10,7 @@ THIRD_PARTY_CONTRACTS_DIR=${THIRD_PARTY_CONTRACTS_DIR:-/opt/contracts_thirdparty
 
 # IMPORTANT! minimum_gas_prices should always contain at least one record, otherwise the chain will not start or halt
 # ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2 denom is required by intgration tests (test:tokenomics)
-MIN_GAS_PRICES_DEFAULT='[{"denom":"ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2","amount":"0"},{"denom":"untrn","amount":"0"}]'
+MIN_GAS_PRICES_DEFAULT='[{"denom":"ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2","amount":"0"},{"denom":"untrn","amount":"0"}],'
 MIN_GAS_PRICES=${MIN_GAS_PRICES:-"$MIN_GAS_PRICES_DEFAULT"}
 
 

--- a/integration-tests/src/testSuite.ts
+++ b/integration-tests/src/testSuite.ts
@@ -105,26 +105,27 @@ const awaitFirstBlock = async (rpc: string): Promise<void> =>
       }
     }, 20_000);
 
-const awaitNeutronChannels = async (rest: string, rpc: string): Promise<void> =>
-    waitFor(async () => {
-      try {
-        const client = new NeutronClient({
-          apiURL: `http://${rest}`,
-          rpcURL: rpc,
-          prefix: 'neutron',
-        });
-        const res = await client.IbcCoreChannelV1.query.queryChannels();
-        if (res.data.channels.length > 0) {
-          let channels = res.data.channels;
-          if (channels.every((c) => c.state === 'STATE_OPEN')) {
-            return true;
-          }
+const awaitNeutronChannels = async (rest: string, rpc: string): Promise<void> => {
+  const client = new NeutronClient({
+    apiURL: `http://${rest}`,
+    rpcURL: rpc,
+    prefix: 'neutron',
+  });
+  await waitFor(async () => {
+    try {
+      const res = await client.IbcCoreChannelV1.query.queryChannels();
+      if (res.data.channels.length > 0) {
+        let channels = res.data.channels;
+        if (channels.every((c) => c.state === 'STATE_OPEN')) {
+          return true;
         }
-      } catch (e) {
-        console.log('failed to find channels: ' + e.message)
-        return false;
       }
-    }, 60_000);
+    } catch (e) {
+      console.log('failed to find channels: ' + e.message)
+      return false;
+    }
+  }, 60_000);
+}
 
 export const generateWallets = async (): Promise<Record<Keys, string>> =>
     keys.reduce(

--- a/integration-tests/testcases/claimer.test.ts
+++ b/integration-tests/testcases/claimer.test.ts
@@ -136,8 +136,8 @@ describe('Test claimer artifact', () => {
 
         // wait until interchain tx is not in progress
         await waitFor(async () => {
-            const inProgress = await client.queryContractSmart(claimerAddress, { interchain_tx_in_progress: {} })
-            return !inProgress
+            const callbackStates = await client.queryContractSmart(claimerAddress, { ibc_callback_states: {} })
+            return callbackStates.length === callbackStatesLengthBefore + 1
         }, 500000)
 
         // expect timeout callback to be called
@@ -173,8 +173,8 @@ describe('Test claimer artifact', () => {
 
         // wait until interchain tx is not in progress
         await waitFor(async () => {
-            const inProgress = await client.queryContractSmart(claimerAddress, { interchain_tx_in_progress: {} })
-            return !inProgress
+            const callbackStates = await client.queryContractSmart(claimerAddress, { ibc_callback_states: {} })
+            return callbackStates.length === callbackStatesLengthBefore + 1
         }, 500000)
 
         // check callbacks
@@ -202,8 +202,8 @@ describe('Test claimer artifact', () => {
 
         // wait until interchain tx is not in progress
         await waitFor(async () => {
-            const inProgress = await client.queryContractSmart(claimerAddress, { interchain_tx_in_progress: {} })
-            return !inProgress
+            const callbackStates = await client.queryContractSmart(claimerAddress, { ibc_callback_states: {} })
+            return callbackStates.length === callbackStatesLengthBefore + 1
         }, 500000)
 
         // balance on contract should be 0 + 2500 refunded timeout fee
@@ -240,8 +240,8 @@ describe('Test claimer artifact', () => {
 
         // wait until interchain tx is not in progress
         await waitFor(async () => {
-            const inProgress = await client.queryContractSmart(claimerAddress, { interchain_tx_in_progress: {} })
-            return !inProgress
+            const callbackStates = await client.queryContractSmart(claimerAddress, { ibc_callback_states: {} })
+            return callbackStates.length === callbackStatesLengthBefore + 1
         }, 500000)
 
         // check new callback
@@ -281,8 +281,8 @@ describe('Test claimer artifact', () => {
 
         // wait until interchain tx is not in progress
         await waitFor(async () => {
-            const inProgress = await client.queryContractSmart(claimerAddress, { interchain_tx_in_progress: {} })
-            return !inProgress
+            const callbackStates = await client.queryContractSmart(claimerAddress, { ibc_callback_states: {} })
+            return callbackStates.length === callbackStatesLengthBefore + 1
         }, 500000)
 
         const ica = await client.queryContractSmart(claimerAddress, { interchain_account: {} })
@@ -302,8 +302,8 @@ describe('Test claimer artifact', () => {
 
         // wait until interchain tx is not in progress
         await waitFor(async () => {
-            const inProgress = await client.queryContractSmart(claimerAddress, { interchain_tx_in_progress: {} })
-            return !inProgress
+            const callbackStates = await client.queryContractSmart(claimerAddress, { ibc_callback_states: {} })
+            return callbackStates.length === callbackStatesLengthBefore + 1
         }, 500000)
 
         // should return callback

--- a/src/msg.rs
+++ b/src/msg.rs
@@ -14,6 +14,9 @@ pub struct InstantiateMsg {
 
     /// relative timeout for ica transactions
     pub ibc_timeout_seconds: u64,
+
+    /// amount of tokens to fund community pool
+    pub amount: Uint128,
 }
 
 #[cw_serde]
@@ -25,7 +28,7 @@ pub enum ExecuteMsg {
     SendClaimedTokensToICA {},
 
     /// Requires ICA to be created and open. Funds cosmoshub community pool with given `amount` of funds.
-    FundCommunityPool { amount: Uint128 },
+    FundCommunityPool {},
 }
 
 #[cw_serde]
@@ -46,4 +49,7 @@ pub struct MigrateMsg {
 
     // ica address to send funds to
     pub ica_address: Option<String>,
+
+    // amount to fund community pool
+    pub amount: Option<Uint128>,
 }

--- a/src/msg.rs
+++ b/src/msg.rs
@@ -34,9 +34,6 @@ pub enum QueryMsg {
     #[returns(Option<crate::state::InterchainAccount>)]
     InterchainAccount {},
 
-    #[returns(bool)]
-    InterchainTxInProgress {},
-
     #[returns(Vec<crate::state::IbcCallbackState>)]
     IbcCallbackStates {},
 }

--- a/src/state.rs
+++ b/src/state.rs
@@ -6,9 +6,6 @@ pub const CONFIG: Item<Config> = Item::new("config");
 
 pub const INTERCHAIN_ACCOUNT: Item<Option<InterchainAccount>> = Item::new("interchain_account");
 
-// if true, interchain operation is in progress and we cannot make an operation
-pub const INTERCHAIN_TX_IN_PROGRESS: Item<bool> = Item::new("interchain_tx_in_progress");
-
 // to understand what happened with IBC calls
 pub const IBC_CALLBACK_STATES: Item<Vec<IbcCallbackState>> = Item::new("ibc_callback_states");
 

--- a/src/state.rs
+++ b/src/state.rs
@@ -1,4 +1,5 @@
 use cosmwasm_schema::cw_serde;
+use cosmwasm_std::Uint128;
 use cw_storage_plus::Item;
 use neutron_sdk::sudo::msg::RequestPacket;
 
@@ -15,6 +16,7 @@ pub struct Config {
     pub transfer_channel_id: String,
     pub ibc_neutron_denom: String,
     pub ibc_timeout_seconds: u64,
+    pub amount: Uint128,
 }
 
 #[cw_serde]


### PR DESCRIPTION
What pr fixes:
- In initialisation add `amount` field that will be used in FundCommunityPool execution instead of an argument to avoid spam with invalid argument
- Removed interchain_tx_in_progress since it does not make stages after deletion of stages and also can make contract unusable forever
